### PR TITLE
BUGFIX: Prevent JS error with missing translations

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Javascript.fusion
+++ b/Resources/Private/Fusion/Prototypes/Javascript.fusion
@@ -19,7 +19,8 @@ prototype(Jonnitto.Plyr:Javascript) < prototype(Neos.Fusion:Array) {
                 i18n = Neos.Fusion:Collection {
                     collection = ${['restart','rewind','play','pause','fastForward','seek','seekLabel','played','buffered','currentTime','duration','volume','mute','unmute','enableCaptions','disableCaptions','enterFullscreen','exitFullscreen','frameTitle','captions','settings','menuBack','speed','normal','quality','loop','start','end','all','reset','disabled','enabled','advertisement','qualityBadge']}
                     itemRenderer = Neos.Fusion:Value {
-                        translation = ${Translation.translate(item, null, [], null, 'Jonnitto.Plyr')}
+                        englishDefault = ${Translation.translate(item, null, [], null, 'Jonnitto.Plyr', null, 'en')}
+                        translation = ${Translation.translate(item, this.englishDefault, [], null, 'Jonnitto.Plyr')}
                         wrappedTranslation = ${item == 'qualityBadge' ? this.translation : ("'" + this.translation + "'")}
                         value = ${item + ":" + this.wrappedTranslation + (iterator.isLast ? '' : ',')}
                     }


### PR DESCRIPTION
The package uses language labels for javascript options and when
the language not exists the option for qualityBadge (an object) leads
to an javascript error. So we are now using the english language as default.

Describe the big picture of your changes here to communicate to the maintainers why I should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/jonnitto/Jonnitto.Plyr/blob/master/.github/CONTRIBUTING.md) when submitting a pull request.
